### PR TITLE
[FIX] 메시지 수신 루프 수정 

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,8 +15,8 @@ import (
 
 func main() {
 
-	// kafka producer 생성                        // "kafka:9092"
-	producer, err := kafka.NewChatProducer("kafka:9092", "chat-topic") // 컨테이너 통신이므로 서비스명으로
+	// kafka producer 생성
+	producer, err := kafka.NewChatProducer("kafka:9092", "chat-topic") // 컨테이너 통신일 때는 서비스명(kafka)로 변경
 	if err != nil {
 		log.Fatalf("Kafka producer 생성 실패: %v", err)
 	}


### PR DESCRIPTION
### 첫 번째 메시지 두 번 전송 오류 
원인: 메시지가 수신될 때 서버 내에서 브로드캐스트 함수를 호출
해결: 메시지 수신 루프에서 kafka로만 전송되도록 수정 